### PR TITLE
Fix connection management in db.cpp and improve reliability

### DIFF
--- a/Login/MyForm1.h
+++ b/Login/MyForm1.h
@@ -234,7 +234,7 @@ namespace Login {
 		}
 
 		try {
-			this->data->AbrirConeccion();
+			this->data->AbrirConeccion(); // Opens connection
 			// Using parameterized queries to prevent SQL injection.
 			String^ query = "INSERT INTO user (user, clave, rol, departamento) VALUES (@user, @clave, @rol, @departamento)";
 			MySql::Data::MySqlClient::MySqlCommand^ cmd = gcnew MySql::Data::MySqlClient::MySqlCommand(query, this->data->GetConnection());
@@ -266,8 +266,8 @@ namespace Login {
 			MessageBox::Show("Ocurrió un error: " + ex->Message, "Error", MessageBoxButtons::OK, MessageBoxIcon::Error);
 		}
 		finally {
-			if (this->data != nullptr) { // Check if data is not null
-				this->data->CerrarConeccion();
+			if (this->data != nullptr) {
+				this->data->CerrarConeccion(); // Closes connection after insert attempt
 			}
 		}
 	}
@@ -277,15 +277,16 @@ namespace Login {
 	}
 	public: void Consulta() {
 		try {
-			this->data->AbrirConeccion();
-			this->datasss->DataSource = this->data->getData();
+			this->data->AbrirConeccion(); // Opens connection
+			this->datasss->DataSource = this->data->getData(); // getData presumably uses the open connection
 		}
 		catch (Exception^ ex) {
+			// If error occurs here, connection might remain open if CerrarConeccion is not called in finally by getData or similar
 			MessageBox::Show("Error al cargar datos: " + ex->Message, "Error de carga de datos", MessageBoxButtons::OK, MessageBoxIcon::Error);
 		}
 		finally {
-			if (this->data != nullptr) { // Check if data is not null
-				this->data->CerrarConeccion();
+			if (this->data != nullptr) {
+				this->data->CerrarConeccion(); // Closes connection after fetching data
 			}
 		}
 	}

--- a/Login/db.cpp
+++ b/Login/db.cpp
@@ -7,16 +7,35 @@ db::db() {
 }
 
 void db::AbrirConeccion() {
-	this->conn->Open();
+	if (this->conn != nullptr && this->conn->State != ConnectionState::Open) {
+		try {
+			this->conn->Open();
+		}
+		catch (MySqlException^ ex) {
+			// Optional: Log exception or handle as needed
+			// For now, rethrow to make the caller aware.
+			throw ex;
+		}
+	}
 }
 
 void db::CerrarConeccion() {
-	this->conn->Close();
+	if (this->conn != nullptr && this->conn->State == ConnectionState::Open) {
+		try {
+			this->conn->Close();
+		}
+		catch (MySqlException^ ex) {
+			// Optional: Log exception or handle as needed
+			throw ex;
+		}
+	}
 }
 
 
 
 DataTable^ db::getData() {
+	// This method assumes the connection is managed (opened/closed) by the caller.
+	// If it's not, it would need its own try/finally for Open/Close.
 	String^ sql = "select * from user";
 	MySqlCommand^ cursor = gcnew MySqlCommand(sql, this->conn);
 	MySqlDataAdapter^ data = gcnew MySqlDataAdapter(cursor);


### PR DESCRIPTION
- Modified db::AbrirConeccion to check if the connection is already open before attempting to open it.
- Modified db::CerrarConeccion to check if the connection is already closed before attempting to close it.
- These changes prevent 'connection already open' errors, particularly when refreshing data after an insert operation.
- Previous changes include parameterizing SQL queries to prevent SQL injection and ensuring MyForm1 opens correctly.